### PR TITLE
set_mode and launch command at same time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           export VERSION=$(echo "$GITHUB_REF" | sed -e 's!refs/tags/!!')
           curl -L "https://github.com/tcnksm/ghr/releases/download/${GHR_VERSION}/ghr_${GHR_VERSION}_linux_amd64.tar.gz" | tar xvz
-          "ghr_${GHR_VERSION}_linux_amd64/ghr" -u k0kubun -r xremap -replace -n "$VERSION" "$VERSION" package/
+          "ghr_${GHR_VERSION}_linux_amd64/ghr" -u xremap -r xremap -replace -n "$VERSION" "$VERSION" package/
         env:
           GHR_VERSION: v0.16.2
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,8 @@ jobs:
           key: ubuntu-latest
       - run: cargo test
 
-  publish:
+  # Release xremap binaries on GitHub
+  release:
     runs-on: ubuntu-latest
     needs:
       - build
@@ -75,9 +76,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
-        with:
-          key: ubuntu-latest
 
       # Fetch x86_64 binary
       - { uses: actions/download-artifact@v3, with: { name: xremap-x86_64-x11,     path: package/ } }
@@ -104,6 +102,24 @@ jobs:
         env:
           GHR_VERSION: v0.16.2
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Publish xremap to crates.io
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ubuntu-latest
 
       # Release crate
       - name: cargo login

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,5 +109,5 @@ jobs:
           curl -L "https://github.com/tcnksm/ghr/releases/download/${GHR_VERSION}/ghr_${GHR_VERSION}_linux_amd64.tar.gz" | tar xvz
           "ghr_${GHR_VERSION}_linux_amd64/ghr" -u k0kubun -r xremap -replace -n "$VERSION" "$VERSION" package/
         env:
-          GHR_VERSION: v0.14.0
+          GHR_VERSION: v0.16.2
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,13 +79,6 @@ jobs:
         with:
           key: ubuntu-latest
 
-      # Release crate
-      - name: cargo login
-        run: cargo login "$CARGO_TOKEN"
-        env:
-          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
-      - run: cargo publish
-
       # Fetch x86_64 binary
       - { uses: actions/download-artifact@v3, with: { name: xremap-x86_64-x11,     path: package/ } }
       - { uses: actions/download-artifact@v3, with: { name: xremap-x86_64-gnome,   path: package/ } }
@@ -111,3 +104,10 @@ jobs:
         env:
           GHR_VERSION: v0.16.2
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Release crate
+      - name: cargo login
+        run: cargo login "$CARGO_TOKEN"
+        env:
+          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
+      - run: cargo publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.8.16
+
+- Add `window` matcher for the `wlroots` client [#447](https://github.com/k0kubun/xremap/issues/447)
+
 ## v0.8.15
 
 - Add `skip_key_event` option to `press`/`release` modmap action [#420](https://github.com/k0kubun/xremap/issues/420)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.8.16
 
 - Add `window` matcher for the `wlroots` client [#447](https://github.com/k0kubun/xremap/issues/447)
+- Handle new KWin API for the `kde` client [#437](https://github.com/k0kubun/xremap/issues/437)
 
 ## v0.8.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.8.15
+
+- Add `skip_key_event` option to `press`/`release` modmap action [#420](https://github.com/k0kubun/xremap/issues/420)
+
 ## v0.8.14
 
 - Support TOML as a config file format [#404](https://github.com/k0kubun/xremap/issues/404)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## v0.8.18
-
-- Fix issues in the release pipeline
-
 ## v0.8.17
 
 - Add `window` matcher for the `kde` client [#448](https://github.com/xremap/xremap/pull/448)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.8.18
+
+- Fix issues in the release pipeline
+
 ## v0.8.17
 
 - Add `window` matcher for the `kde` client [#448](https://github.com/xremap/xremap/pull/448)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.8.17
+
+- Add `window` matcher for the `kde` client [#448](https://github.com/xremap/xremap/pull/448)
+
 ## v0.8.16
 
 - Add `window` matcher for the `wlroots` client [#447](https://github.com/k0kubun/xremap/issues/447)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.33"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap 2.2.2",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "instant"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.31"
+version = "0.9.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
 dependencies = [
  "indexmap 2.2.2",
  "itoa",
@@ -1591,9 +1591,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,7 +1893,7 @@ checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
 
 [[package]]
 name = "xremap"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "humantime",
  "is-terminal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "async-io"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.109"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,7 +1893,7 @@ checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
 
 [[package]]
 name = "xremap"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,14 +1540,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.1",
+ "toml_edit 0.22.8",
 ]
 
 [[package]]
@@ -1567,20 +1567,20 @@ checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.2.2",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.3",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
 dependencies = [
  "indexmap 2.2.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -1857,6 +1857,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,7 +1913,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "swayipc",
- "toml 0.8.9",
+ "toml 0.8.12",
  "wayland-client",
  "wayland-protocols-wlr",
  "x11rb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,18 +1232,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,7 +1893,7 @@ checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
 
 [[package]]
 name = "xremap"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
 
 [[package]]
 name = "xremap"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
 dependencies = [
  "base64",
  "chrono",
@@ -1293,6 +1293,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.2.2",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -1300,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,7 +1893,7 @@ checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
 
 [[package]]
 name = "xremap"
-version = "0.8.18"
+version = "0.8.17"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fork"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2ca97a59201425e7ee4d197c9c4fea282fe87a97d666a580bda889b95b8e88"
+checksum = "60e74d3423998a57e9d906e49252fb79eb4a04d5cdfe188fb1b7ff9fc076a8ed"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,9 +687,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyprland"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa94ae7899f3f1bdcad21dcd50366a60f323375a25610889246f276d7f9fb06"
+checksum = "f87a8f1cc065d451894dd3916c0bc3fcf9b67b276126c05f27b1db912688dde8"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -1371,18 +1371,18 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wayland-client = { version = "0.30", optional = true }
 wayland-protocols-wlr = { version = "0.1", features = ["client"], optional = true }
 x11rb = { version = "0.13.0", optional = true }
 zbus = { version = "1.9.2", optional = true }
-hyprland = { version = "0.3.12", optional = true }
+hyprland = { version = "0.3.13", optional = true }
 toml = "0.8.9"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xremap"
-version = "0.8.18"
+version = "0.8.17"
 edition = "2021"
 description = "Dynamic key remapp for X and Wayland"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ wayland-protocols-wlr = { version = "0.1", features = ["client"], optional = tru
 x11rb = { version = "0.13.0", optional = true }
 zbus = { version = "1.9.2", optional = true }
 hyprland = { version = "0.3.13", optional = true }
-toml = "0.8.9"
+toml = "0.8.12"
 
 [features]
 gnome = ["zbus"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xremap"
-version = "0.8.14"
+version = "0.8.15"
 edition = "2021"
 description = "Dynamic key remapp for X and Wayland"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0.79"
 clap = { version = "4.3.19", features = ["derive"] }
 clap_complete = "4.3.2"
 derive-where = "1.2.7"
-env_logger = "0.10.1"
+env_logger = "0.10.2"
 evdev = "0.12.1"
 fork = "0.1"
 indoc = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xremap"
-version = "0.8.16"
+version = "0.8.17"
 edition = "2021"
 description = "Dynamic key remapp for X and Wayland"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ nix = "0.26.2"
 regex = "1.10.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_with = { version = "3.6", features = ["chrono"] }
+serde_with = { version = "3.7", features = ["chrono"] }
 serde_yaml = "0.9"
 swayipc = { version = "3.0.1", optional = true }
 wayland-client = { version = "0.30", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ evdev = "0.12.1"
 fork = "0.1"
 indoc = "2.0"
 lazy_static = "1.4.0"
-log = "0.4.20"
+log = "0.4.21"
 nix = "0.26.2"
 regex = "1.10.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xremap"
-version = "0.8.15"
+version = "0.8.16"
 edition = "2021"
 description = "Dynamic key remapp for X and Wayland"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/k0kubun/xremap"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.79"
+anyhow = "1.0.81"
 clap = { version = "4.3.19", features = ["derive"] }
 clap_complete = "4.3.2"
 derive-where = "1.2.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xremap"
-version = "0.8.17"
+version = "0.8.18"
 edition = "2021"
 description = "Dynamic key remapp for X and Wayland"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ indoc = "2.0"
 lazy_static = "1.4.0"
 log = "0.4.21"
 nix = "0.26.2"
-regex = "1.10.3"
+regex = "1.10.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.7", features = ["chrono"] }

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ modmap:
         alone_timeout_millis: 1000 # Optional
       # Hook `keymap` action on key press/release events.
       KEY_XXX:
+        skip_key_event: false # Optional, skip original key event ,defaults to false
         press: { launch: ["xdotool", "mousemove", "0", "7200"] } # Required
         release: { launch: ["xdotool", "mousemove", "0", "0"] } # Required
     application: # Optional

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ modmap:
       not: [Application, ...]
       # or
       only: [Application, ...]
+    window: # Optional (only wlroots clients supported)
+      not: [/regex of window title/, ...]
+      # or
+      only: [/regex of window title/, ...]
     device: # Optional
       not: [Device, ...]
       # or
@@ -262,6 +266,10 @@ keymap:
       not: [Application, ...]
       # or
       only: [Application, ...]
+    window: # Optional (only wlroots clients supported)
+      not: [/regex of window title/, ...]
+      # or
+      only: [/regex of window title/, ...]
     device: # Optional
       not: [Device, ...]
       # or

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ Some [custom aliases](src/config/key.rs) like `SHIFT_R`, `CONTROL_L`, etc. are p
 
 In case you don't know the name of a key, you can find out by enabling the xremap debug output:
 ```bash
-RUST_LOG=debug xremap path/to/your/configuration
-#or 
-sudo RUST_LOG=debug xremap path/to/your/configuration
+RUST_LOG=debug xremap config.yml
+# or
+sudo RUST_LOG=debug xremap config.yml
 ```
 Then press the key you want to know the name of.
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,11 @@ keymap:
       MOD1-KEY_XXX: { escape_next_key: true }
       # Set mode to configure Vim-like modal remapping
       MOD1-KEY_XXX: { set_mode: default }
+      # Set mode and launch command at same time
+      MOD1-KEY_XXX:
+        set_mode: test
+        launch: ["notify-send", "test mode"]
+
     application: # Optional
       not: [Application, ...]
       # or

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ modmap:
       not: [Application, ...]
       # or
       only: [Application, ...]
-    window: # Optional (only wlroots clients supported)
+    window: # Optional (only wlroots/kde clients supported)
       not: [/regex of window title/, ...]
       # or
       only: [/regex of window title/, ...]
@@ -266,7 +266,7 @@ keymap:
       not: [Application, ...]
       # or
       only: [Application, ...]
-    window: # Optional (only wlroots clients supported)
+    window: # Optional (only wlroots/kde clients supported)
       not: [/regex of window title/, ...]
       # or
       only: [/regex of window title/, ...]
@@ -344,7 +344,7 @@ However, it will only start printing, once a mapping has been triggered that use
 So you have to create a mapping with a filter using a dummy application name and trigger it.
 Then each time you switch to a new window xremap will print its caption, class, and name in the following style:
 `active window: caption: '<caption>', class: '<class>', name: '<name>'`
-You want to use the class for the filter.  
+The `class` property should be used for application matching, while the `caption` property should be used for window matching.
 
 If you use a systemd-daemon to manage xremap, the prints will be visible in the system-logs (Can be opened with `journalctl -f`)
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ For `KEY_XXX` and `KEY_YYY`, use [these names](https://github.com/emberian/evdev
 You can skip `KEY_` and the name is case-insensitive. So `KEY_CAPSLOCK`, `CAPSLOCK`, and `CapsLock` are the same thing.
 Some [custom aliases](src/config/key.rs) like `SHIFT_R`, `CONTROL_L`, etc. are provided.
 
+In case you don't know the name of a key, you can find out by enabling the xremap debug output:
+```bash
+RUST_LOG=debug xremap path/to/your/configuration
+#or 
+sudo RUST_LOG=debug xremap path/to/your/configuration
+```
+Then press the key you want to know the name of.
+
 If you specify a map containing `held` and `alone`, you can use the key for two purposes.
 The key is considered `alone` if it's pressed and released within `alone_timeout_millis` (default: 1000)
 before any other key is pressed. Otherwise it's considered `held`.

--- a/src/client/gnome_client.rs
+++ b/src/client/gnome_client.rs
@@ -24,6 +24,10 @@ impl Client for GnomeClient {
         self.connect();
         self.current_application().is_some()
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         self.connect();

--- a/src/client/hypr_client.rs
+++ b/src/client/hypr_client.rs
@@ -12,6 +12,10 @@ impl Client for HyprlandClient {
     fn supported(&mut self) -> bool {
         true
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         if let Ok(win_opt) = HyprClient::get_active() {

--- a/src/client/kde_client.rs
+++ b/src/client/kde_client.rs
@@ -174,12 +174,12 @@ impl Client for KdeClient {
         conn_res.is_ok()
     }
     fn current_window(&mut self) -> Option<String> {
-        // TODO:  not implemented
-        None
+        let aw = self.active_window.lock().ok()?;
+        Some(aw.title.clone())
     }
 
     fn current_application(&mut self) -> Option<String> {
-        let aw = self.active_window.lock().unwrap();
+        let aw = self.active_window.lock().ok()?;
         Some(aw.res_class.clone())
     }
 }

--- a/src/client/kde_client.rs
+++ b/src/client/kde_client.rs
@@ -173,6 +173,10 @@ impl Client for KdeClient {
         }
         conn_res.is_ok()
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         let aw = self.active_window.lock().unwrap();

--- a/src/client/kwin-script.js
+++ b/src/client/kwin-script.js
@@ -1,4 +1,4 @@
-workspace.clientActivated.connect(function(client){
+function notifyActiveWindow(client) {
     callDBus(
         "com.k0kubun.Xremap",
         "/com/k0kubun/Xremap",
@@ -8,4 +8,12 @@ workspace.clientActivated.connect(function(client){
         "resourceClass" in client ? client.resourceClass : "",
         "resourceName" in client ? client.resourceName : ""
     );
-});
+}
+
+if (workspace.windowList) {
+    // kde 6
+    workspace.windowActivated.connect(notifyActiveWindow);
+} else {
+    // kde 5
+    workspace.clientActivated.connect(notifyActiveWindow);
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,7 @@
 pub trait Client {
     fn supported(&mut self) -> bool;
     fn current_application(&mut self) -> Option<String>;
+    fn current_window(&mut self) -> Option<String>;
 }
 
 pub struct WMClient {
@@ -8,6 +9,7 @@ pub struct WMClient {
     client: Box<dyn Client>,
     supported: Option<bool>,
     last_application: String,
+    last_window: String,
 }
 
 impl WMClient {
@@ -17,7 +19,27 @@ impl WMClient {
             client,
             supported: None,
             last_application: String::new(),
+            last_window: String::new(),
         }
+    }
+    pub fn current_window(&mut self) -> Option<String> {
+        if self.supported.is_none() {
+            let supported = self.client.supported();
+            self.supported = Some(supported);
+            println!("application-client: {} (supported: {})", self.name, supported);
+        }
+        if !self.supported.unwrap() {
+            return None;
+        }
+
+        let result = self.client.current_window();
+        if let Some(window) = &result {
+            if &self.last_window != window {
+                self.last_window = window.clone();
+                println!("window: {}", window);
+            }
+        }
+        result
     }
 
     pub fn current_application(&mut self) -> Option<String> {

--- a/src/client/null_client.rs
+++ b/src/client/null_client.rs
@@ -6,6 +6,9 @@ impl Client for NullClient {
     fn supported(&mut self) -> bool {
         false
     }
+    fn current_window(&mut self) -> Option<String> {
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         None

--- a/src/client/sway_client.rs
+++ b/src/client/sway_client.rs
@@ -40,6 +40,10 @@ impl Client for SwayClient {
         self.connect();
         self.connection.is_some()
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         self.connect();

--- a/src/client/x11_client.rs
+++ b/src/client/x11_client.rs
@@ -48,6 +48,10 @@ impl Client for X11Client {
         return self.connection.is_some();
         // TODO: Test XGetInputFocus and focused_window > 0?
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         self.connect();

--- a/src/config/application.rs
+++ b/src/config/application.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer};
 // TODO: Use trait to allow only either `only` or `not`
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Application {
+pub struct OnlyOrNot {
     #[serde(default, deserialize_with = "deserialize_matchers")]
     pub only: Option<Vec<ApplicationMatcher>>,
     #[serde(default, deserialize_with = "deserialize_matchers")]

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -1,5 +1,5 @@
 use crate::config::application::deserialize_string_or_vec;
-use crate::config::application::Application;
+use crate::config::application::OnlyOrNot;
 use crate::config::key_press::KeyPress;
 use crate::config::keymap_action::{Actions, KeymapAction};
 use evdev::Key;
@@ -17,7 +17,8 @@ pub struct Keymap {
     pub name: String,
     #[serde(deserialize_with = "deserialize_remap")]
     pub remap: HashMap<KeyPress, Vec<KeymapAction>>,
-    pub application: Option<Application>,
+    pub application: Option<OnlyOrNot>,
+    pub window: Option<OnlyOrNot>,
     pub device: Option<Device>,
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub mode: Option<Vec<String>>,
@@ -41,7 +42,8 @@ where
 pub struct KeymapEntry {
     pub actions: Vec<KeymapAction>,
     pub modifiers: Vec<Modifier>,
-    pub application: Option<Application>,
+    pub application: Option<OnlyOrNot>,
+    pub title: Option<OnlyOrNot>,
     pub device: Option<Device>,
     pub mode: Option<Vec<String>>,
     pub exact_match: bool,
@@ -65,6 +67,7 @@ pub fn build_keymap_table(keymaps: &Vec<Keymap>) -> HashMap<Key, Vec<KeymapEntry
                 actions: actions.to_vec(),
                 modifiers: key_press.modifiers.clone(),
                 application: keymap.application.clone(),
+                title: keymap.window.clone(),
                 device: keymap.device.clone(),
                 mode: keymap.mode.clone(),
                 exact_match: keymap.exact_match,

--- a/src/config/modmap.rs
+++ b/src/config/modmap.rs
@@ -1,4 +1,4 @@
-use crate::config::application::Application;
+use crate::config::application::OnlyOrNot;
 use crate::config::key::deserialize_key;
 use crate::config::modmap_action::ModmapAction;
 use evdev::Key;
@@ -14,7 +14,8 @@ pub struct Modmap {
     pub name: String,
     #[serde(deserialize_with = "deserialize_remap")]
     pub remap: HashMap<Key, ModmapAction>,
-    pub application: Option<Application>,
+    pub application: Option<OnlyOrNot>,
+    pub window: Option<OnlyOrNot>,
     pub device: Option<Device>,
 }
 

--- a/src/config/modmap_action.rs
+++ b/src/config/modmap_action.rs
@@ -31,6 +31,8 @@ pub struct MultiPurposeKey {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct PressReleaseKey {
+    #[serde(default)]
+    pub skip_key_event: bool ,
     #[serde(deserialize_with = "deserialize_actions")]
     pub press: Vec<KeymapAction>,
     #[serde(deserialize_with = "deserialize_actions")]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -200,6 +200,25 @@ fn test_yaml_keymap_mode() {
 }
 
 #[test]
+fn test_yaml_keymap_mode_launch() {
+    yaml_assert_parse(indoc! {r#"
+    default_mode: insert
+    keymap:
+      - mode: insert
+        remap:
+          Esc: { set_mode: normal, launch: ["wmctrl", "-x", "-a", "code.Code"] }
+    
+      - mode: normal
+        remap:
+          i: { set_mode: insert }
+          h: Left
+          j: Down
+          k: Up
+          l: Right
+    "#})
+}
+
+#[test]
 fn test_yaml_keymap_mark() {
     yaml_assert_parse(indoc! {"
     keymap:

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -3,7 +3,7 @@ use crate::client::WMClient;
 use crate::config::application::OnlyOrNot;
 use crate::config::key_press::{KeyPress, Modifier};
 use crate::config::keymap::{build_override_table, OverrideEntry};
-use crate::config::keymap_action::KeymapAction;
+use crate::config::keymap_action::{KeymapAction, ModeAction};
 use crate::config::modmap_action::{Keys, ModmapAction, MultiPurposeKey, PressReleaseKey};
 use crate::config::remap::Remap;
 use crate::device::InputDeviceInfo;
@@ -539,8 +539,16 @@ impl EventHandler {
             }
             KeymapAction::Launch(command) => self.run_command(command.clone()),
             KeymapAction::SetMode(mode) => {
-                self.mode = mode.clone();
-                println!("mode: {}", mode);
+                match mode {
+                    ModeAction::Set(set_only) => {
+                        let mode = set_only.clone().remove("set_mode").unwrap_or_default();
+                        self.mode = mode.clone();
+                    },
+                    ModeAction::SetLaunch(set) => {
+                        self.run_command(set.command.clone());
+                        self.mode = set.name.clone();
+                    }
+                }
             }
             KeymapAction::SetMark(set) => self.mark_set = *set,
             KeymapAction::WithMark(key_press) => self.send_key_press(&self.with_mark(key_press)),

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -329,7 +329,7 @@ impl EventHandler {
                 // fallthrough on state discrepancy
                 vec![(key, value)]
             }
-            ModmapAction::PressReleaseKey(PressReleaseKey { press, release }) => {
+            ModmapAction::PressReleaseKey(PressReleaseKey { skip_key_event, press, release }) => {
                 // Just hook actions, and then emit the original event. We might want to
                 // support reordering the key event and dispatched actions later.
                 if value == PRESS || value == RELEASE {
@@ -344,8 +344,14 @@ impl EventHandler {
                         &key,
                     )?;
                 }
-                // Dispatch the original key as well
-                vec![(key, value)]
+
+                if skip_key_event {
+                    // Do not dispatch the original key
+                    vec![(Key::KEY_UNKNOWN, value)]
+                } else {
+                    // dispatch the original key
+                    vec![(key, value)]
+                }
             }
         };
         Ok(keys)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,6 +23,9 @@ impl Client for StaticClient {
     fn supported(&mut self) -> bool {
         true
     }
+    fn current_window(&mut self) -> Option<String> {
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         self.current_application.clone()


### PR DESCRIPTION
- **allow to skip key event on KeyRelease actions (#420)**
- **Version 0.8.15**
- **Bump serde from 1.0.196 to 1.0.197**
- **Bump env_logger from 0.10.1 to 0.10.2**
- **Bump hyprland from 0.3.12 to 0.3.13**
- **Bump serde_json from 1.0.109 to 1.0.114**
- **Handle new KWin API for kde-backend.**
- **Added info on how to find unknown keynames to Readme. (#438)**
- **Use `xremap config.yml` consistently**
- **Bump anyhow from 1.0.79 to 1.0.81**
- **Bump toml from 0.8.9 to 0.8.12**
- **Bump serde_yaml from 0.9.31 to 0.9.33**
- **Bump fork from 0.1.22 to 0.1.23**
- **Bump log from 0.4.20 to 0.4.21**
- **Window matcher for modmap and keymap (wlroots client only) (#447)**
- **Version 0.8.16**
- **Add an entry to CHANGELOG**
- **KDE: Add support for window matching. (#448)**
- **Version 0.8.17**
- **Update GHR_VERSION**
- **Reorder release operations**
- **Version 0.8.18**
- **Revert "Version 0.8.18"**
- **The username has been changed to xremap**
- **Version 0.8.18**
- **Split release and publish**
- **Revert "Version 0.8.18"**
- **Version 0.8.18**
- **Bump serde_with from 3.6.0 to 3.7.0**
- **Bump serde_yaml from 0.9.33 to 0.9.34+deprecated**
- **Bump serde_json from 1.0.114 to 1.0.115**
- **Bump regex from 1.10.3 to 1.10.4**
- **Bump indoc from 2.0.4 to 2.0.5**
- **set_mode and launch command at same time**
